### PR TITLE
Fix issue 1

### DIFF
--- a/bin/value_todo
+++ b/bin/value_todo
@@ -1,3 +1,5 @@
+require 'value_todo'
+
 begin
   ValueTodo::BuildValueTodoListUseCase.execute
 rescue => e

--- a/bin/value_todo
+++ b/bin/value_todo
@@ -1,3 +1,5 @@
-#!/usr/bin/env bash
-
-echo hoge
+begin
+  BuildValueTodoListUseCase.execute
+rescue => e
+  puts e
+end

--- a/bin/value_todo
+++ b/bin/value_todo
@@ -1,5 +1,5 @@
 begin
-  BuildValueTodoListUseCase.execute
+  ValueTodo::BuildValueTodoListUseCase.execute
 rescue => e
   puts e
 end


### PR DESCRIPTION
fix #1

以下のファイルが gem を install すると作成されて、`#!/usr/bin/env ruby` のマジックコメントが付いているのが確認出来たので、Ruby Script 書く必要があった。

```ruby
[vendor/bundle/ruby/2.7.0/bin/value_todo]

#!/usr/bin/env ruby
#
# This file was generated by RubyGems.
#
# The application 'value_todo' is installed as part of a gem, and
# this file is here to facilitate running it.
#

require 'rubygems'

version = ">= 0.a"

str = ARGV.first
if str
  str = str.b[/\A_(.*)_\z/, 1]
  if str and Gem::Version.correct?(str)
    version = str
    ARGV.shift
  end
end

if Gem.respond_to?(:activate_bin_path)
load Gem.activate_bin_path('value_todo', 'value_todo', version)
else
gem "value_todo", version
load Gem.bin_path("value_todo", "value_todo", version)
end
```

# 動作確認
- [x] このブランチを `bundle install` できる事
- [x] `bundle exec value_todo` でエラーが起きずに、value_todo.md が作成される事